### PR TITLE
Fix paths when building on Windows

### DIFF
--- a/src/main/scala/com/typesafe/sbt/uglify/SbtUglify.scala
+++ b/src/main/scala/com/typesafe/sbt/uglify/SbtUglify.scala
@@ -94,7 +94,7 @@ object SbtUglify extends AutoPlugin {
         inputFiles =>
           streams.value.log.info("Optimizing JavaScript with Uglify")
 
-          val outputFile = buildDir.value / output.value.replaceAll("/", java.io.File.separator)
+          val outputFile = buildDir.value / output.value.replaceAllLiterally("/", java.io.File.separator)
 
           val inputFileArgs = inputFiles.map(_.getPath)
 


### PR DESCRIPTION
On Windows, File.separator is `\` which must be escaped to `\\` in the regex.
