### PR TITLE
Add a concat setting function to determine how to combine inputs

### DIFF
--- a/src/sbt-test/sbt-uglify/uglify-concat/build.sbt
+++ b/src/sbt-test/sbt-uglify/uglify-concat/build.sbt
@@ -1,0 +1,17 @@
+lazy val root = (project in file(".")).enablePlugins(SbtWeb)
+
+libraryDependencies += "org.webjars" % "bootstrap" % "3.0.2"
+
+pipelineStages := Seq(uglify)
+
+UglifyKeys.uglifyOps := { js =>
+  Seq((js.sortBy(_._2), "concat.min.js"))
+}
+
+val checkMapFileContents = taskKey[Unit]("check that map contents are correct")
+
+checkMapFileContents := {
+  val contents = IO.read(file("target/web/stage/concat.min.js.map"))
+  if (!contents.contains("""{"version":3,"file":"concat.min.js","sources":["javascripts/a.js","javascripts/b.js","javascripts/x.js"],"names":["a","b","define","number","opposite","call","this"],"mappings":"""))
+    sys.error(s"Unexpected contents: $contents")
+}

--- a/src/sbt-test/sbt-uglify/uglify-concat/project/build.properties
+++ b/src/sbt-test/sbt-uglify/uglify-concat/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.5

--- a/src/sbt-test/sbt-uglify/uglify-concat/project/plugins.sbt
+++ b/src/sbt-test/sbt-uglify/uglify-concat/project/plugins.sbt
@@ -1,0 +1,8 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-uglify" % sys.props("project.version"))
+
+resolvers ++= Seq(
+  Resolver.mavenLocal,
+  Resolver.url("sbt snapshot plugins", url("http://repo.scala-sbt.org/scalasbt/sbt-plugin-snapshots"))(Resolver.ivyStylePatterns),
+  Resolver.sonatypeRepo("snapshots"),
+  "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
+)

--- a/src/sbt-test/sbt-uglify/uglify-concat/src/main/assets/javascripts/a.js
+++ b/src/sbt-test/sbt-uglify/uglify-concat/src/main/assets/javascripts/a.js
@@ -1,0 +1,3 @@
+function a() {
+	return 1;
+}

--- a/src/sbt-test/sbt-uglify/uglify-concat/src/main/assets/javascripts/b.js
+++ b/src/sbt-test/sbt-uglify/uglify-concat/src/main/assets/javascripts/b.js
@@ -1,0 +1,3 @@
+function b() {
+	return 2;
+}

--- a/src/sbt-test/sbt-uglify/uglify-concat/src/main/assets/javascripts/x.coffee
+++ b/src/sbt-test/sbt-uglify/uglify-concat/src/main/assets/javascripts/x.coffee
@@ -1,0 +1,3 @@
+define ->
+  number   = 42
+  opposite = true

--- a/src/sbt-test/sbt-uglify/uglify-concat/src/main/assets/javascripts/x.js
+++ b/src/sbt-test/sbt-uglify/uglify-concat/src/main/assets/javascripts/x.js
@@ -1,0 +1,10 @@
+(function() {
+  define(function() {
+    var number, opposite;
+    number = 42;
+    return opposite = true;
+  });
+
+}).call(this);
+
+//# sourceMappingURL=x.js.map

--- a/src/sbt-test/sbt-uglify/uglify-concat/src/main/assets/javascripts/x.js.map
+++ b/src/sbt-test/sbt-uglify/uglify-concat/src/main/assets/javascripts/x.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "file": "x.js",
+  "sourceRoot": "",
+  "sources": [
+    "x.coffee"
+  ],
+  "names": [],
+  "mappings": "AAAA;AAAA,EAAA,MAAA,CAAO,SAAA,GAAA;AACL,QAAA,gBAAA;AAAA,IAAA,MAAA,GAAW,EAAX,CAAA;WACA,QAAA,GAAW,KAFN;EAAA,CAAP,CAAA,CAAA;AAAA"
+}

--- a/src/sbt-test/sbt-uglify/uglify-concat/test
+++ b/src/sbt-test/sbt-uglify/uglify-concat/test
@@ -1,0 +1,21 @@
+# Uglify files.
+
+> web-stage
+$ exists target/web/stage/javascripts/a.js
+$ absent target/web/stage/javascripts/a.min.js
+$ absent target/web/stage/javascripts/a.min.js.map
+$ exists target/web/stage/javascripts/b.js
+$ absent target/web/stage/javascripts/b.min.js
+$ absent target/web/stage/javascripts/b.min.js.map
+$ exists target/web/stage/javascripts/x.coffee
+$ exists target/web/stage/javascripts/x.js
+$ exists target/web/stage/javascripts/x.js.map
+$ absent target/web/stage/javascripts/x.min.js
+$ absent target/web/stage/javascripts/x.min.js.map
+$ exists target/web/stage/concat.min.js
+$ exists target/web/stage/concat.min.js.map
+-$ exists target/web/uglify/lib
+
+> checkMapFileContents
+
+


### PR DESCRIPTION
As discussed in issue #2.

This tries to preserve path handling.  In particular, it only uses the relative part of input paths, under appDir (which is really the same as buildDir).  As a result, the concat setting could instead be `Seq[String] => (Seq[String], String)` for simplicity, but I suppose the user may want to get to the file contents as well.
The default behavior is unchanged (except for a tweak to where ".min" is added for files without a ".").  I've tested it in the default case and the everything-to-one case and incremental building still seems to work.
