### PR TITLE
Update sbt-uglify to use UglifyJS 2.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,50 +3,78 @@ sbt-uglify
 
 [![Build Status](https://api.travis-ci.org/sbt/sbt-uglify.png?branch=master)](https://travis-ci.org/sbt/sbt-uglify)
 
-An SBT plugin to perform [UglifyJs optimization](http://lisperator.net/uglifyjs).
+An sbt-web plugin to perform [UglifyJS optimization](https://github.com/mishoo/UglifyJS2) on the asset pipeline.
 
-To use this plugin use the addSbtPlugin command within your project's `plugins.sbt` file:
+Usage
+-----
+To use this plugin, use the addSbtPlugin command within your project's `plugins.sbt` file:
 
-    addSbtPlugin("com.typesafe.sbt" % "sbt-uglify" % "1.0.3")
+```scala
+addSbtPlugin("com.typesafe.sbt" % "sbt-uglify" % "1.0.3")
+```
 
-Your project's build file also needs to enable sbt-web plugins. For example with build.sbt:
+Your project's build file also needs to enable sbt-web plugins. For example, with build.sbt:
 
-    lazy val root = (project in file(".")).enablePlugins(SbtWeb)
+```scala
+lazy val root = (project in file(".")).enablePlugins(SbtWeb)
+```
 
-As with all sbt-web asset pipeline plugins you must declare their order of execution e.g.:
+As with all sbt-web asset pipeline plugins you must declare their order of execution:
 
 ```scala
 pipelineStages := Seq(uglify)
 ```
 
-A standard build profile for the Uglify optimizer is provided which will mangle variables for obfuscation and 
-compress. Each input `.js` file found in your assets folders will have a corresponding `.min.js` file and source maps are also generated. 
-If you wish to limit or extend what is uglified then you can use filters e.g.:
+A standard build profile for the Uglify optimizer is provided which will mangle variables for obfuscation and
+compression. Each input `.js` file found in your assets folders will have a corresponding `.min.js` file and source maps will also be generated.
 
+## includeFilter
+
+If you wish to limit or extend what is uglified then you can use filters:
 ```scala
 includeFilter in uglify := GlobFilter("myjs/*.js"),
 ```
+...where the above will include only those files under the `myjs` folder.
 
-...where the above will include only those files under the `myjs` folder. The sbt `excludeFilter` is also available 
-to the `uglify` scope and defaults to excluding the public folder and extracted Webjars.
+The sbt `excludeFilter` is also available to the `uglify` scope and defaults to excluding the public folder and extracted Webjars.
 
+## uglifyOps
+
+If you wish to change how files are mapped from input to output, you can change the `uglifyOps` setting to point at another grouping.
+
+The default ops takes a source file and produces minified file and source map:
+```scala
+UglifyKeys.uglifyOps := UglifyOps.singleFileWithSourceMapOut
+```
+
+This ops takes a source file and produces minified file only (no source map):
+```scala
+UglifyKeys.uglifyOps := UglifyOps.singleFile
+```
+
+This ops takes a source file and source map and produces minified file and combined source map. Your includeFilter must include source map files for this to work:
+```scala
+UglifyKeys.uglifyOps := UglifyOps.singleFileWithSourceMapInAndOut
+```
+
+## Settings
 You are able to use and/or customize settings already made, and add your own. Here are a list of relevant settings and
-their meanings (please refer to the [UglifyJs documentation](http://lisperator.net/uglifyjs) for details on the 
+their meanings (please refer to the [UglifyJS documentation](https://github.com/mishoo/UglifyJS2) for details on the
 options):
 
-Option                  | Description
-------------------------|------------
-comments                | Specifies comments handling. Defaults to None.
-compress                | Enables compression. The default is to compress. Set to false to not compress.
-compressOptions         | A sequence of options for compression such as hoist_vars, if_return etc.
-define                  | Define globals. Defaults to None.
-enclose                 | Enclose in one big function. Defaults to false.
-mangle                  | Enables name mangling. The default is to mangle.
-mangleOptions           | Options for mangling such as sort, topLevel etc.
-preamble                | Any preamble to include at the start of the output. Defaults to None.
-reserved                | Reserved names to exclude from mangling.
-sourceMap               | Enables source maps. The default is that source maps are enabled (true).
-uglifyOps               | A function defining how to combine input files into output files, taking the list of included inputs and returning the list of output files that should be generated along with their sources. Defaults to a one-to-one mapping, uglifying each file.js to file.min.js separately.")
+Option                  | Description                                                                                   | Default
+------------------------|-----------------------------------------------------------------------------------------------|----------
+comments                | Specifies comments handling.                                                                  | `None`
+compress                | Enables compression. Set true to compress.                                                    | `true`
+compressOptions         | A sequence of options for compression such as hoist_vars, if_return etc.                      | `Nil`
+define                  | Define globals.                                                                               | `None`
+enclose                 | Enclose in one big function.                                                                  | `false`
+includeSource           | Include the content of source files in the source map as the sourcesContent property.         | `false`
+mangle                  | Enables name mangling.                                                                        | `true`
+mangleOptions           | Options for mangling such as sort, topLevel etc.                                              | `Nil`
+preamble                | Any preamble to include at the start of the output.                                           | `None`
+reserved                | Reserved names to exclude from mangling.                                                      | `Nil`
+uglifyOps               | A function defining how to combine input files into output files.                             | `UglifyOps.singleFileWithSourceMapOut`
 
 The plugin is built on top of [JavaScript Engine](https://github.com/typesafehub/js-engine) which supports different JavaScript runtimes.
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ scalaVersion := "2.10.4"
 scalacOptions += "-feature"
 
 libraryDependencies ++= Seq(
-  "org.webjars" % "uglifyjs" % "2.4.13"
+  "org.webjars.npm" % "uglify-js" % "2.6.2"
 )
 
 resolvers ++= Seq(
@@ -22,7 +22,7 @@ resolvers ++= Seq(
   Resolver.mavenLocal
 )
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-js-engine" % "1.0.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-js-engine" % "1.1.2")
 
 publishMavenStyle := false
 

--- a/src/sbt-test/sbt-uglify/uglify-concat/build.sbt
+++ b/src/sbt-test/sbt-uglify/uglify-concat/build.sbt
@@ -5,13 +5,15 @@ libraryDependencies += "org.webjars" % "bootstrap" % "3.0.2"
 pipelineStages := Seq(uglify)
 
 UglifyKeys.uglifyOps := { js =>
-  Seq((js.sortBy(_._2), "concat.min.js"))
+  Seq(UglifyOps.UglifyOpGrouping(js.sortBy(_._2), "javascripts/concat.min.js", None, Some("javascripts/concat.min.js.map")))
 }
 
 val checkMapFileContents = taskKey[Unit]("check that map contents are correct")
 
 checkMapFileContents := {
-  val contents = IO.read(file("target/web/stage/concat.min.js.map"))
-  if (!contents.contains("""{"version":3,"file":"concat.min.js","sources":["javascripts/a.js","javascripts/b.js","javascripts/x.js"],"names":["a","b","define","number","opposite","call","this"],"mappings":"""))
+  val contents = IO.read(file("target/web/stage/javascripts/concat.min.js.map"))
+  if (!contents.contains("""{"version":3,"sources":["a.js","b.js","x.js"],"names":["a","b","define","number","opposite","call","this"],"mappings":""") ||
+    !contents.contains(""","file":"concat.min.js"}""")) {
     sys.error(s"Unexpected contents: $contents")
+  }
 }

--- a/src/sbt-test/sbt-uglify/uglify-concat/test
+++ b/src/sbt-test/sbt-uglify/uglify-concat/test
@@ -12,8 +12,8 @@ $ exists target/web/stage/javascripts/x.js
 $ exists target/web/stage/javascripts/x.js.map
 $ absent target/web/stage/javascripts/x.min.js
 $ absent target/web/stage/javascripts/x.min.js.map
-$ exists target/web/stage/concat.min.js
-$ exists target/web/stage/concat.min.js.map
+$ exists target/web/stage/javascripts/concat.min.js
+$ exists target/web/stage/javascripts/concat.min.js.map
 -$ exists target/web/uglify/lib
 
 > checkMapFileContents

--- a/src/sbt-test/sbt-uglify/uglify/build.sbt
+++ b/src/sbt-test/sbt-uglify/uglify/build.sbt
@@ -8,7 +8,7 @@ val checkMapFileContents = taskKey[Unit]("check that map contents are correct")
 
 checkMapFileContents := {
   val contents = IO.read(file("target/web/stage/javascripts/a.min.js.map"))
-  val r = """\{"version":3,"file":"a.min.js","sources":\["a.js"\],"names":\["a"\],"mappings":"AAAA,QAASA,KACR,MAAO"\}""".r
+  val r = """\{"version":3,"sources":\["a.js"\],"names":\["a"\],"mappings":"AAAA,QAASA,KACR,MAAO","file":"a.min.js"\}""".r
   if (r.findAllIn(contents).isEmpty) {
     sys.error(s"Unexpected contents: $contents")
   }


### PR DESCRIPTION
Update sbt-uglify to use UglifyJS 2.6.2.

Also miscellaneous changes:
- Changed interface of the `uglifyOps` key and removed the `sourceMaps` key (see objectmastery/sbt-uglify#1).
- Removed `appDir` as it is redundant, and trying to separate it from `buildDir` causes source maps to be generated that are incorrect (see objectmastery/sbt-uglify#2).
- Added key `includeSources` to allow source files to be included inside of source maps in the sourcesContent property (see objectmastery/sbt-uglify#3).
