### PR TITLE
Use a newer uglify version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ name := "sbt-uglify"
 description := "sbt-web plugin for minifying JavaScript files"
 addSbtJsEngine("1.2.2")
 libraryDependencies ++= Seq(
-  "org.webjars.npm" % "uglify-js" % "2.8.14",
+  "org.webjars.npm" % "uglify-js" % "3.16.3",
   "io.monix" %% "monix" % "2.3.3"
 )
 

--- a/src/main/scala/com/typesafe/sbt/uglify/SbtUglify.scala
+++ b/src/main/scala/com/typesafe/sbt/uglify/SbtUglify.scala
@@ -247,11 +247,10 @@ object SbtUglify extends AutoPlugin {
 
               val (outputMapFile, outputMapFileArgs) = if (grouping.outputMapFile.isDefined) {
                 val outputMapFile = buildDirValue / grouping.outputMapFile.get
-                IO.createDirectory(outputMapFile.getParentFile)
+                val directory = outputMapFile.getParentFile
+                IO.createDirectory(directory)
                 (Some(outputMapFile), Seq(
-                  "--source-map", outputMapFile.getPath,
-                  "--source-map-url", outputMapFile.getName,
-                  "--prefix", "relative"))
+                  "--source-map", s"base='${directory.getPath}',filename='${directory.toPath.relativize(outputFile.toPath)}',url='${outputMapFile.getName}'"))
               } else {
                 (None, Nil)
               }

--- a/src/sbt-test/sbt-uglify/uglify-concat/build.sbt
+++ b/src/sbt-test/sbt-uglify/uglify-concat/build.sbt
@@ -12,8 +12,13 @@ val checkMapFileContents = taskKey[Unit]("check that map contents are correct")
 
 checkMapFileContents := {
   val contents = IO.read(file("target/web/stage/javascripts/concat.min.js.map"))
-  if (!contents.contains("""{"version":3,"sources":["a.js","b.js","x.js"],"names":["a","b","define","call","this"],"mappings":""") ||
-    !contents.contains(""","file":"concat.min.js"}""")) {
+  if (
+    !contents.contains(""""version":3""") ||
+    !contents.contains(""""sources":["a.js","b.js","x.js"]""") ||
+    !contents.contains(""""names":["a","b","define","call","this"]""") ||
+    !contents.contains(""""mappings":""") || 
+    !contents.contains(""""file":"concat.min.js"""")
+    ) {
     sys.error(s"Unexpected contents: $contents")
   }
 }

--- a/src/sbt-test/sbt-uglify/uglify/build.sbt
+++ b/src/sbt-test/sbt-uglify/uglify/build.sbt
@@ -8,7 +8,7 @@ val checkMapFileContents = taskKey[Unit]("check that map contents are correct")
 
 checkMapFileContents := {
   val contents = IO.read(file("target/web/stage/javascripts/a.min.js.map"))
-  val r = """\{"version":3,"sources":\["a.js"\],"names":\["a"\],"mappings":"AAAA,QAASA,KACR,MAAO","file":"a.min.js"\}""".r
+  val r = """\{"version":3,"file":"a.min.js","sources":\["a.js"\],"names":\["a"\],"mappings":"AAAA,SAASA,IACR,OAAO"\}""".r
   if (r.findAllIn(contents).isEmpty) {
     sys.error(s"Unexpected contents: $contents")
   }


### PR DESCRIPTION
After upgrading to Node 19, sbt-uglify no longer works, due to UglifyJS version 2.8.14 calling making FS calls with incorrect types. Bumping to 3.16.3 (the latest available on webjars) fixes that but some of the command-line arguments have also been changed.

I've tested this change and it fixes the problem on my project